### PR TITLE
2.0.1 reintroduce OTAcceleratorCoreBundle

### DIFF
--- a/OTAcceleratorCore.podspec
+++ b/OTAcceleratorCore.podspec
@@ -19,9 +19,9 @@ On the Android and iOS mobile platforms, when you try to set a listener (Android
 
   s.source_files = 'OTAcceleratorCore/**/*.{h,m}'
 
-  # s.resource_bundles = {
-  # 	'OTAcceleratorCoreBundle' => ['OTAcceleratorCoreBundle/**/*']
-  # }
+  s.resource_bundles = {
+    'OTAcceleratorCoreBundle' => ['OTAcceleratorCoreBundle/**/*.xib', 'OTAcceleratorCoreBundle/Assets.xcassets']
+  }
 
   s.static_framework = true
   s.public_header_files = 'OTAcceleratorCore/**/*.{h}'


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts. Confirmation: ____

#### This fixes issue OTAcceleratorCoreBundle (assets and xibs) were not being bundled in with the pod. This was like commented out due to an error that arises. 

Note how the resources folder was missing:
|Before | After |
|---|---|
| ![broken](https://user-images.githubusercontent.com/15106299/95327015-5b523780-089b-11eb-9c3b-6303885df1bf.png) |  ![fixed](https://user-images.githubusercontent.com/15106299/95327039-62794580-089b-11eb-9c17-e391bd1b014c.png)|
